### PR TITLE
build: sets up automated releases with semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app (macOS)
+        if: matrix.os == 'macos-latest'
+        run: npm run dist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build app (Windows)
+        if: matrix.os == 'windows-latest'
+        run: npm run dist:win
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts (macOS)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-build
+          path: dist/*.dmg
+
+      - name: Upload artifacts (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: |
+            dist/*.exe
+            dist/*.zip
+
+  semantic-release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    needs: release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-build
+          path: dist/
+
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+          path: dist/
+
+      - name: List dist contents
+        run: ls -la dist/
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,45 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "dist/*.dmg",
+            "label": "macOS Installer"
+          },
+          {
+            "path": "dist/*.exe", 
+            "label": "Windows Installer"
+          },
+          {
+            "path": "dist/*.zip",
+            "label": "Portable Archive"
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -52,3 +52,28 @@ npm run dist:all
 ```
 
 Built apps will be in the `dist/` folder.
+
+## Releases
+
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release) for automated releases. 
+
+### Commit Message Format
+
+To trigger releases, use conventional commit messages:
+
+- `feat: add new feature` - triggers a minor release
+- `fix: fix a bug` - triggers a patch release  
+- `feat!: breaking change` or `BREAKING CHANGE:` in commit body - triggers a major release
+
+### Release Process
+
+1. Push commits to the `main` branch
+2. GitHub Actions automatically builds for macOS and Windows
+3. If semantic-release detects releasable changes, it creates a new release with:
+   - Automated version bump
+   - Generated changelog
+   - macOS .dmg installer
+   - Windows .exe installer
+   - Portable .zip archives
+
+Releases are published to GitHub Releases with all platform binaries attached.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
   },
   "devDependencies": {
     "electron": "latest",
-    "electron-builder": "^26.0.12"
+    "electron-builder": "^26.0.12",
+    "semantic-release": "^22.0.0",
+    "@semantic-release/changelog": "^6.0.0",
+    "@semantic-release/git": "^10.0.0",
+    "@semantic-release/github": "^9.0.0"
   },
   "build": {
     "appId": "com.yourname.pomodoro-timer",
@@ -34,5 +38,45 @@
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true
     }
+  },
+  "release": {
+    "branches": ["main"],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": ["CHANGELOG.md", "package.json"],
+          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        }
+      ],
+      [
+        "@semantic-release/github",
+        {
+          "assets": [
+            {
+              "path": "dist/*.dmg",
+              "label": "macOS Installer"
+            },
+            {
+              "path": "dist/*.exe",
+              "label": "Windows Installer"
+            },
+            {
+              "path": "dist/*.zip",
+              "label": "Portable Archive"
+            }
+          ]
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
Configures semantic-release to automate versioning, changelog generation, and release publishing to GitHub Releases.

This includes:

- Setting up a GitHub Actions workflow to build and package the application for macOS and Windows.
- Configuring semantic-release to analyze commit messages, generate release notes, and publish binaries.
- Defining the commit message format for triggering releases.

The release workflow automatically builds for macOS and Windows, detects releasable changes, and creates new releases with automated version bumps, generated changelogs, and platform-specific binaries.